### PR TITLE
Update urls.py

### DIFF
--- a/rest_framework_social_oauth2/urls.py
+++ b/rest_framework_social_oauth2/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import url, include
+from django.conf.urls import include
+from django.urls import re_path as url
 from oauth2_provider.views import AuthorizationView
 
 from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions, DisconnectBackendView


### PR DESCRIPTION
Resolves the error
ImportError: cannot import name 'url' from 'django.conf.urls' 
in urls.py after upgrading to Django 4.0